### PR TITLE
Hotfix v1.1.2

### DIFF
--- a/FyneApp.toml
+++ b/FyneApp.toml
@@ -4,5 +4,5 @@ Website = "https://github.com/beebeeoii/lominus"
   Icon = "./assets/app-icon.png"
   Name = "Lominus"
   ID = "com.beebeeoii.lominus"
-  Version = "1.1.1"
-  Build = 50
+  Version = "1.1.2"
+  Build = 60

--- a/internal/lominus/lominus.go
+++ b/internal/lominus/lominus.go
@@ -2,7 +2,7 @@ package lominus
 
 const APP_NAME = "Lominus"
 const APP_ID = "com.lominus.beebeeoii"
-const APP_VERSION = "1.1.1"
+const APP_VERSION = "1.1.2"
 
 const LOCK_FILE_NAME = "lominus.lock"
 

--- a/pkg/api/request.go
+++ b/pkg/api/request.go
@@ -35,7 +35,7 @@ const (
 	GET_FOLDERS   = 0
 	GET_ALL_FILES = 1
 	DOWNLOAD_FILE = 2
-	get_files     = 3
+	GET_FILES     = 3
 )
 
 const USER_AGENT = "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:94.0) Gecko/20100101 Firefox/94.0"
@@ -99,7 +99,7 @@ func BuildDocumentRequest(builder interface{}, mode int) (DocumentRequest, error
 			return DocumentRequest{}, errors.New("invalid arguments: DocumentRequest must be built using File to download")
 		}
 		urlEndpoint = DOWNLOAD_URL_ENDPOINT
-	case get_files:
+	case GET_FILES:
 		urlEndpoint = FILE_URL_ENDPOINT
 	default:
 		return DocumentRequest{}, errors.New("invalid arguments: mode provided is not a valid mode")


### PR DESCRIPTION
Fixes #17 files in base directory of modules are not downloaded. Deprecated `GetAllFiles()` - build a `DocumentRequest` with a Folder instead of a `Module` instead, and call `getRootFiles()` directly in the future