### PR TITLE
ui: remove close button from ui window

### DIFF
--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -62,7 +62,6 @@ func Init() error {
 		tabsContainer,
 		layout.NewSpacer(),
 		getSyncButton(w),
-		getQuitButton(),
 	)
 
 	w.SetContent(content)
@@ -117,13 +116,5 @@ func getSyncButton(parentWindow fyne.Window) *widget.Button {
 			return
 		}
 		cron.Rerun(getPreferences().Frequency)
-	})
-}
-
-// getQuitButton builds the quit button in the main UI.
-func getQuitButton() *widget.Button {
-	return widget.NewButton(appConstants.QUIT_LOMINUS_TEXT, func() {
-		logs.Logger.Infoln("lominus quit")
-		mainApp.Quit()
 	})
 }


### PR DESCRIPTION
This MR removes the close button in the main window.

Considerations for removing the close button:
1. There is already a close button via the systray which users can (and would) use to close the application completely, rendering the close button in the main window quite useless.
2. The button takes up space and clutters the main window more than it should. With it, the height of the window is possibly longer than the height of many laptop screens.