### PR TITLE
style: removed desc and changed folder open text

### DIFF
--- a/internal/constants/ui.go
+++ b/internal/constants/ui.go
@@ -25,9 +25,9 @@ const (
 	PREFERENCES_TITLE = "Preferences"
 
 	FILE_DIRECTORY_TAB_TITLE             = "File Directory"
-	FILE_DIRECTORY_TAB_DESCRIPTION       = "Select the root folder to store all your modules' files."
-	FILE_DIRECTORY_FOLDER_PATH_DEFAULT   = "Folder path not set"
+	FILE_DIRECTORY_FOLDER_PATH_DEFAULT   = "Select the root folder to store all your modules' files."
 	FILE_DIRECTORY_SELECT_DIRECTORY_TEXT = "Choose folder"
+	FILE_DIRECTORY_CHOOSE_LOCATION_TEXT  = "Choose"
 
 	SYNC_TAB_TITLE             = "Sync"
 	SYNC_TAB_DESCRIPTION       = "Sync files and more **automatically** at the frequency specified below."

--- a/internal/ui/preferences.go
+++ b/internal/ui/preferences.go
@@ -58,8 +58,6 @@ func getFileDirectoryView(parentWindow fyne.Window) (fyne.CanvasObject, error) {
 		fyne.TextAlignLeading,
 		fyne.TextStyle{Bold: true, Italic: false, Monospace: false, TabWidth: 0},
 	)
-	description := widget.NewRichTextFromMarkdown(appConstants.FILE_DIRECTORY_TAB_DESCRIPTION)
-	description.Wrapping = fyne.TextWrapWord
 
 	dir := getPreferences().Directory
 	if dir == "" {
@@ -69,7 +67,7 @@ func getFileDirectoryView(parentWindow fyne.Window) (fyne.CanvasObject, error) {
 	folderPathLabel := widget.NewLabel(dir)
 	folderPathLabel.Wrapping = fyne.TextWrapWord
 	chooseDirButton := widget.NewButton(appConstants.FILE_DIRECTORY_SELECT_DIRECTORY_TEXT, func() {
-		dialog.ShowFolderOpen(func(lu fyne.ListableURI, dirErr error) {
+		fileDialog := dialog.NewFolderOpen(func(lu fyne.ListableURI, dirErr error) {
 			if dirErr != nil {
 				logs.Logger.Debugln("directory selection cancelled")
 				dialog.NewInformation(
@@ -116,9 +114,11 @@ func getFileDirectoryView(parentWindow fyne.Window) (fyne.CanvasObject, error) {
 			logs.Logger.Debugln("directory saved")
 			folderPathLabel.SetText(preferences.Directory)
 		}, parentWindow)
+		fileDialog.SetConfirmText(appConstants.FILE_DIRECTORY_CHOOSE_LOCATION_TEXT)
+		fileDialog.Show()
 	})
 
-	return container.NewVBox(label, widget.NewSeparator(), description, folderPathLabel, chooseDirButton), nil
+	return container.NewVBox(label, widget.NewSeparator(), folderPathLabel, chooseDirButton), nil
 }
 
 func getSyncView(parentWindow fyne.Window) (fyne.CanvasObject, error) {


### PR DESCRIPTION
This MR addresses some minor UI changes to the File Directory section under Preferences.

- removes the description text
- changes the default text for the folder path
- changes the "select folder" button in the folder dialog from "open" to "choose"