### PR TITLE
fix: band aid for pagination issues

### DIFF
--- a/pkg/constants/endpoints.go
+++ b/pkg/constants/endpoints.go
@@ -3,10 +3,10 @@ package constants
 // Canvas Endpoints
 const (
 	CANVAS_USER_SELF_ENDPOINT      = "https://canvas.nus.edu.sg/api/v1/users/self"
-	CANVAS_MODULES_ENDPOINT        = "https://canvas.nus.edu.sg/api/v1/courses"
-	CANVAS_MODULE_FOLDERS_ENDPOINT = "https://canvas.nus.edu.sg/api/v1/courses/%s/folders"
-	CANVAS_FOLDERS_ENDPOINT        = "https://canvas.nus.edu.sg/api/v1/folders/%s/folders"
-	CANVAS_FILES_ENDPOINT          = "https://canvas.nus.edu.sg/api/v1/folders/%s/files"
+	CANVAS_MODULES_ENDPOINT        = "https://canvas.nus.edu.sg/api/v1/courses?per_page=30"
+	CANVAS_MODULE_FOLDERS_ENDPOINT = "https://canvas.nus.edu.sg/api/v1/courses/%s/folders?per_page=30"
+	CANVAS_FOLDERS_ENDPOINT        = "https://canvas.nus.edu.sg/api/v1/folders/%s/folders?per_page=30"
+	CANVAS_FILES_ENDPOINT          = "https://canvas.nus.edu.sg/api/v1/folders/%s/files?per_page=30"
 	CANVAS_FILE_ENDPOINT           = "https://canvas.nus.edu.sg/api/v1/files/%s"
 )
 


### PR DESCRIPTION
This MR increases the maximum number of items returned per request from the default of 10 to 30. This is a band-aid fix and should not be the long term solution.

addresses #55 