### PR TITLE
fix: files in root canvas folders not downloaded

### DIFF
--- a/internal/cron/cron.go
+++ b/internal/cron/cron.go
@@ -175,7 +175,10 @@ func createJob(frequency int) (*gocron.Job, error) {
 
 		canvasFolders := []api.Folder{}
 		for _, module := range canvasModules {
-			// TODO Check if it is even possible for files to be in module's root folder
+			// Note that there is no need to ensure that the files in the module's root
+			// folder are downloaded. They are already downloaded as those files are
+			// already put into a folder "course files" by Canvas which are downloaded.
+			// Check out files.go GetFiles() for more details.
 			folders, canvasFoldersErr := getFolders(tokensData.CanvasToken.CanvasApiToken, constants.Canvas, module)
 			if canvasFoldersErr != nil {
 				// TODO Somehow collate this error and display to user at the end

--- a/pkg/interfaces/Folder.go
+++ b/pkg/interfaces/Folder.go
@@ -6,12 +6,13 @@ type FolderObject interface {
 
 // TODO Documentation
 type CanvasFolderObject struct {
-	Id            int    `json:"id"`
-	Name          string `json:"name"`
-	FullName      string `json:"full_name"`
-	HiddenForUser bool   `json:"hidden_for_user"`
-	FilesCount    int    `json:"files_count"`
-	FoldersCount  int    `json:"folders_count"`
+	Id             int    `json:"id"`
+	Name           string `json:"name"`
+	FullName       string `json:"full_name"`
+	HiddenForUser  bool   `json:"hidden_for_user"`
+	FilesCount     int    `json:"files_count"`
+	FoldersCount   int    `json:"folders_count"`
+	ParentFolderId int    `json:"parent_folder_id"`
 }
 
 type LuminusFolderObject struct {


### PR DESCRIPTION
This MR addresses #61. Previous assumption of files in Canvas must be put in folders and are not allowed to be uploaded to the module's root folder is wrong.