### PR TITLE
fix: canvas file updated field

### DIFF
--- a/pkg/interfaces/File.go
+++ b/pkg/interfaces/File.go
@@ -7,7 +7,7 @@ type CanvasFileObject struct {
 	UUID          string `json:"uuid"`
 	Url           string `json:"url"`
 	HiddenForUser bool   `json:"hidden_for_user"`
-	LastUpdated   string `json:"updated_at"`
+	LastUpdated   string `json:"modified_at"`
 }
 
 // TODO Documentation


### PR DESCRIPTION
This MR changes the `CanvasFileObject` `lastUpdated` field from `updated_at` to `modified_at`. `modified_at` is accurate field that denotes when the file has been reuploaded by the professor, which is what we want.