### PR TITLE
fix: Nested folders not retrieved / in wrong directory

### DIFF
--- a/internal/cron/cron.go
+++ b/internal/cron/cron.go
@@ -173,67 +173,47 @@ func createJob(frequency int) (*gocron.Job, error) {
 			return
 		}
 
-		canvasFolders := []api.Folder{}
+		lmsFiles := []api.File{}
 		for _, module := range canvasModules {
-			// Note that there is no need to ensure that the files in the module's root
-			// folder are downloaded. They are already downloaded as those files are
-			// already put into a folder "course files" by Canvas which are downloaded.
-			// Check out files.go GetFiles() for more details.
-			folders, canvasFoldersErr := getFolders(tokensData.CanvasToken.CanvasApiToken, constants.Canvas, module)
-			if canvasFoldersErr != nil {
-				// TODO Somehow collate this error and display to user at the end
-				// notifications.NotificationChannel <- notifications.Notification{Title: "Sync", Content: canvasFoldersErr.Error()}
-				logs.Logger.Errorln(canvasFoldersErr)
+			foldersReq, foldersReqErr := api.BuildFoldersRequest(
+				tokensData.CanvasToken.CanvasApiToken,
+				constants.Canvas,
+				module,
+			)
+			if foldersReqErr != nil {
+				logs.Logger.Errorln(foldersReqErr)
 			}
-			canvasFolders = append(canvasFolders, folders...)
+
+			files, foldersErr := foldersReq.GetRootFiles()
+			if foldersErr != nil {
+				logs.Logger.Errorln(foldersErr)
+			}
+
+			lmsFiles = append(lmsFiles, files...)
 		}
 
-		luminusFolders := []api.Folder{}
 		for _, module := range luminusModules {
-			// This ensures that files in the module's root folder are downloaded as well.
-			moduleMainFolder := api.Folder{
-				Id:           module.Id,
-				Name:         module.Name,
-				Downloadable: module.IsAccessible,
-				HasSubFolder: true,       // doesn't matter
-				Ancestors:    []string{}, // main folder does not have any ancestors
+			foldersReq, foldersReqErr := api.BuildFoldersRequest(
+				tokensData.LuminusToken.JwtToken,
+				constants.Luminus,
+				module,
+			)
+			if foldersReqErr != nil {
+				logs.Logger.Errorln(foldersReqErr)
 			}
-			folders, luminusFoldersErr := getFolders(tokensData.LuminusToken.JwtToken, constants.Luminus, module)
-			if luminusFoldersErr != nil {
-				// TODO Somehow collate this error and display to user at the end
-				// notifications.NotificationChannel <- notifications.Notification{Title: "Sync", Content: luminusFoldersErr.Error()}
-				logs.Logger.Errorln(luminusFoldersErr)
+
+			files, foldersErr := foldersReq.GetRootFiles()
+			if foldersErr != nil {
+				logs.Logger.Errorln(foldersErr)
 			}
-			luminusFolders = append(luminusFolders, moduleMainFolder)
-			luminusFolders = append(luminusFolders, folders...)
+
+			lmsFiles = append(lmsFiles, files...)
 		}
 
 		nFilesToUpdate := 0
 		filesUpdated := []api.File{}
 
-		files := []api.File{}
-		for _, folder := range canvasFolders {
-			canvasFiles, canvasFilesErr := getFiles(tokensData.CanvasToken.CanvasApiToken, constants.Canvas, folder)
-			if canvasFilesErr != nil {
-				// TODO Somehow collate this error and display to user at the end
-				// notifications.NotificationChannel <- notifications.Notification{Title: "Sync", Content: canvasFilesErr.Error()}
-				logs.Logger.Errorln(canvasFilesErr)
-			}
-			files = append(files, canvasFiles...)
-
-		}
-
-		for _, folder := range luminusFolders {
-			luminusFiles, luminusFilesErr := getFiles(tokensData.LuminusToken.JwtToken, constants.Luminus, folder)
-			if luminusFilesErr != nil {
-				// TODO Somehow collate this error and display to user at the end
-				// notifications.NotificationChannel <- notifications.Notification{Title: "Sync", Content: luminusFilesErr.Error()}
-				logs.Logger.Errorln(luminusFilesErr)
-			}
-			files = append(files, luminusFiles...)
-		}
-
-		for _, file := range files {
+		for _, file := range lmsFiles {
 			key := fmt.Sprintf("%s/%s", strings.Join(file.Ancestors, "/"), file.Name)
 			localLastUpdated := currentFiles[key].LastUpdated
 			platformLastUpdated := file.LastUpdated
@@ -326,38 +306,6 @@ func getModules(token string, platform constants.Platform) ([]api.Module, error)
 	}
 
 	return modules, nil
-}
-
-func getFolders(token string, platform constants.Platform, module api.Module) ([]api.Folder, error) {
-	folders := []api.Folder{}
-
-	foldersReq, foldersReqErr := api.BuildFoldersRequest(token, platform, module)
-	if foldersReqErr != nil {
-		return folders, foldersReqErr
-	}
-
-	folders, foldersErr := foldersReq.GetFolders()
-	if foldersErr != nil {
-		return folders, foldersErr
-	}
-
-	return folders, nil
-}
-
-func getFiles(token string, platform constants.Platform, folder api.Folder) ([]api.File, error) {
-	files := []api.File{}
-
-	filesReq, filesReqErr := api.BuildFilesRequest(token, platform, folder)
-	if filesReqErr != nil {
-		return files, filesReqErr
-	}
-
-	files, filesErr := filesReq.GetFiles()
-	if filesErr != nil {
-		return files, filesErr
-	}
-
-	return files, nil
 }
 
 func getGrades(modules []api.Module) ([]api.Grade, error) {

--- a/pkg/api/files.go
+++ b/pkg/api/files.go
@@ -165,7 +165,7 @@ func (filesRequest FilesRequest) GetFiles() ([]File, error) {
 
 			files = append(files, File{
 				Id:          strconv.Itoa(fileObject.Id),
-				Name:        appFile.CleanseFolderFileName(fileObject.Name),
+				Name:        appFile.CleanseFolderFileName(fileObject.DisplayName),
 				LastUpdated: lastUpdated,
 				Ancestors:   ancestors,
 				DownloadUrl: fileObject.Url,

--- a/pkg/api/files.go
+++ b/pkg/api/files.go
@@ -78,10 +78,21 @@ func (foldersRequest FoldersRequest) GetFolders() ([]Folder, error) {
 		}
 
 		for _, folderObject := range response {
+			// All the folders and files of a module are stored under the "course files" folder.
+			// We do not want to download that folder as we just want the folders and files in that
+			// folder.
+			//
+			// The "course files" folder resembles the 'home directory' of a module.
+			downloadable := !folderObject.HiddenForUser
+
+			if folderObject.FullName == "course files" {
+				downloadable = false
+			}
+
 			folders = append(folders, Folder{
 				Id:           strconv.Itoa(folderObject.Id),
 				Name:         appFile.CleanseFolderFileName(folderObject.Name),
-				Downloadable: !folderObject.HiddenForUser,
+				Downloadable: downloadable,
 				HasSubFolder: folderObject.FoldersCount > 0,
 				Ancestors:    ancestors,
 				IsRootFolder: folderObject.ParentFolderId == 0 &&

--- a/pkg/interfaces/File.go
+++ b/pkg/interfaces/File.go
@@ -2,8 +2,16 @@ package interfaces
 
 // TODO Documentation
 type CanvasFileObject struct {
-	Id            int    `json:"id"`
-	Name          string `json:"filename"`
+	Id   int    `json:"id"`
+	Name string `json:"filename"`
+	// DisplayName is the name that is seen on Canvas Web. It can differ
+	// from the actual name of the file being uploaded.
+	// Using DisplayName would be more accurate as Professors might
+	// set the DisplayName to contain more information for the File.
+	// For eg. filename can be "Tutorial1.pdf" but DisplayName can be
+	// "Tutorial1_HW1.pdf" to show that Tutorial 1 is to be submitted as
+	// a graded Homework.
+	DisplayName   string `json:"display_name"`
 	UUID          string `json:"uuid"`
 	Url           string `json:"url"`
 	HiddenForUser bool   `json:"hidden_for_user"`


### PR DESCRIPTION
This MR addresses 2 bugs:
1. files in nested folders of at least 2 layers (for eg XXX/YYY/file.png) are not downloaded
2. Canvas folders are downloaded but put in the wrong directory

resolves #68, #69 