### PR TITLE
Changed file version naming convention from prepended to appended

### DIFF
--- a/internal/file/file.go
+++ b/internal/file/file.go
@@ -65,12 +65,14 @@ func Exists(name string) bool {
 // X increments itself starting from 1 until the there exists a
 // the new fileName does not exist in the directory.
 func AutoRename(filePath string) string {
-	FORMAT := "%s[v%d]"
+	FORMAT := "%s[v%d]%s"
 	directory, fileName := filepath.Split(filePath)
-	newFileName := fileName
+	fileExtension := filepath.Ext(fileName)
+	fileNameWOExtension := fileName[:len(fileName)-len(fileExtension)]
+	var newFileName string
 
 	for x := 1; ; x++ {
-		newFileName = fmt.Sprintf(FORMAT, fileName, x)
+		newFileName = fmt.Sprintf(FORMAT, fileNameWOExtension, x, fileExtension)
 
 		if !Exists(filepath.Join(directory, newFileName)) {
 			break

--- a/internal/file/file.go
+++ b/internal/file/file.go
@@ -60,24 +60,24 @@ func Exists(name string) bool {
 	return err == nil
 }
 
-// AutoRename renames a file by prepending "[vX]" to its fileName
+// AutoRename renames a file by appending "[vX]" to its fileName
 // where X is a positive integer.
 // X increments itself starting from 1 until the there exists a
 // the new fileName does not exist in the directory.
-func AutoRename(filePath string) error {
-	FORMAT := "[v%d]%s"
+func AutoRename(filePath string) string {
+	FORMAT := "%s[v%d]"
 	directory, fileName := filepath.Split(filePath)
 	newFileName := fileName
 
 	for x := 1; ; x++ {
-		newFileName = fmt.Sprintf(FORMAT, x, fileName)
+		newFileName = fmt.Sprintf(FORMAT, fileName, x)
 
 		if !Exists(filepath.Join(directory, newFileName)) {
 			break
 		}
 	}
 
-	return os.Rename(filePath, filepath.Join(directory, newFileName))
+	return newFileName
 }
 
 // EnsureDir is a helper function that ensures that the directory exists by creating them

--- a/pkg/api/files.go
+++ b/pkg/api/files.go
@@ -376,12 +376,10 @@ func (file File) Download(folderPath string) error {
 
 	// This checks if there already exists the specified file
 	// to prevent overwritting of files.
+	// If file exists, new file will have a new name appended with [vX],
+	// where X is an integer.
 	if appFile.Exists(filePath) {
-		renameErr := appFile.AutoRename(filePath)
-
-		if renameErr != nil {
-			return renameErr
-		}
+		filePath = filepath.Join(folderPath, appFile.AutoRename(filePath))
 	}
 
 	f, err := os.Create(filePath)


### PR DESCRIPTION
This MR modifies how a new version of a file with the same name is named from `[vX]abc.pdf` to `abc[v1].pdf` so that all the `abc.pdf`s can be grouped together when sorted alphabetically.

This change also means that **the most updated version of the file is the one with the highest X**, where X is an integer.

resolves #84 