### PR TITLE
fix: lastUpdated is now based on SG timezone

### DIFF
--- a/pkg/api/files.go
+++ b/pkg/api/files.go
@@ -285,6 +285,9 @@ func (filesRequest FilesRequest) GetFiles() ([]File, error) {
 
 		for _, fileObject := range response {
 			lastUpdated, err := time.Parse(time.RFC3339, fileObject.LastUpdated)
+			tz, _ := time.LoadLocation("Asia/Singapore")
+			lastUpdated = lastUpdated.In(tz)
+
 			if err != nil {
 				return files, err
 			}


### PR DESCRIPTION
This MR resolves the issue where files from Canvas has `lastUpdated` timestamps based 8 hours earlier than Singapore's time because of timezone differences. This is especially obvious from Telegram message updates when a new file is downloaded.

resolves #87 