### PR TITLE
feat: used dashboard to list modules

### DIFF
--- a/pkg/constants/endpoints.go
+++ b/pkg/constants/endpoints.go
@@ -4,7 +4,7 @@ package constants
 // Canvas Endpoints
 const (
 	CANVAS_USER_SELF_ENDPOINT      = "https://canvas.nus.edu.sg/api/v1/users/self"
-	CANVAS_MODULES_ENDPOINT        = "https://canvas.nus.edu.sg/api/v1/courses?per_page=30"
+	CANVAS_MODULES_ENDPOINT        = "https://canvas.nus.edu.sg/api/v1/dashboard/dashboard_cards"
 	CANVAS_MODULE_FOLDER_ENDPOINT  = "https://canvas.nus.edu.sg/api/v1/courses/%s/folders/by_path/"
 	CANVAS_MODULE_FOLDERS_ENDPOINT = "https://canvas.nus.edu.sg/api/v1/courses/%s/folders?per_page=30"
 	CANVAS_FOLDERS_ENDPOINT        = "https://canvas.nus.edu.sg/api/v1/folders/%s/folders?per_page=30"

--- a/pkg/interfaces/Module.go
+++ b/pkg/interfaces/Module.go
@@ -7,10 +7,9 @@ package interfaces
 // relevant ones as of now.
 type CanvasModuleObject struct {
 	Id                       int    `json:"id"`
-	UUID                     string `json:"uuid"`
-	Name                     string `json:"name"`
-	ModuleCode               string `json:"course_code"`
-	IsAccessRestrictedByDate bool   `json:"access_restricted_by_date"`
+	Name                     string `json:"originalName"`
+	ModuleCode               string `json:"courseCode"`
+	IsAccessRestrictedByDate bool   // Automatically false since is still accessible by the Canvas dashboard
 }
 
 // LuminusModuleObject depicts the actual object return from Luminus.


### PR DESCRIPTION
Currently, the Canvas modules from the past semesters are not removed just like how LumiNUS works. A workaround is to use the `dashboard/dashboard_cards` API endpoint to get the list of modules.

By default, if nothing is starred, Canvas will list all the modules ever taken, so there is no significant behaviour change. Otherwise, one can star the modules at https://canvas.nus.edu.sg/courses and only the starred modules will be listed by the API response.