### PR TITLE
fix: max 10 items returned for files/folders

### DIFF
--- a/pkg/constants/endpoints.go
+++ b/pkg/constants/endpoints.go
@@ -6,9 +6,9 @@ const (
 	CANVAS_USER_SELF_ENDPOINT      = "https://canvas.nus.edu.sg/api/v1/users/self"
 	CANVAS_MODULES_ENDPOINT        = "https://canvas.nus.edu.sg/api/v1/dashboard/dashboard_cards"
 	CANVAS_MODULE_FOLDER_ENDPOINT  = "https://canvas.nus.edu.sg/api/v1/courses/%s/folders/by_path/"
-	CANVAS_MODULE_FOLDERS_ENDPOINT = "https://canvas.nus.edu.sg/api/v1/courses/%s/folders?per_page=30"
-	CANVAS_FOLDERS_ENDPOINT        = "https://canvas.nus.edu.sg/api/v1/folders/%s/folders?per_page=30"
-	CANVAS_FILES_ENDPOINT          = "https://canvas.nus.edu.sg/api/v1/folders/%s/files?per_page=30"
+	CANVAS_MODULE_FOLDERS_ENDPOINT = "https://canvas.nus.edu.sg/api/v1/courses/%s/folders"
+	CANVAS_FOLDERS_ENDPOINT        = "https://canvas.nus.edu.sg/api/v1/folders/%s/folders"
+	CANVAS_FILES_ENDPOINT          = "https://canvas.nus.edu.sg/api/v1/folders/%s/files"
 	CANVAS_FILE_ENDPOINT           = "https://canvas.nus.edu.sg/api/v1/files/%s"
 )
 


### PR DESCRIPTION
This MR addresses the limitation of Canvas API where each request returns at maximum 10 items. This caused some folders/files to be skipped when there are more than 10 folders/files. Previously this was band-aided by #56.

Resolves #91 and #55 