### PR TITLE
fix #92

### DIFF
--- a/internal/cron/cron.go
+++ b/internal/cron/cron.go
@@ -169,7 +169,7 @@ func createJob(rootSyncDirectory string, frequency int) (*gocron.Job, error) {
 		filesUpdated := []api.File{}
 
 		for _, file := range lmsFiles {
-			key := fmt.Sprintf("%s/%s", strings.Join(file.Ancestors, "/"), file.Name)
+			key := strings.ToLower(fmt.Sprintf("%s/%s", strings.Join(file.Ancestors, "/"), file.Name))
 			localLastUpdated := currentFiles[key].LastUpdated
 			platformLastUpdated := file.LastUpdated
 

--- a/internal/indexing/indexing.go
+++ b/internal/indexing/indexing.go
@@ -47,7 +47,7 @@ func Build(dir string) (map[string]api.File, error) {
 
 		if !info.IsDir() {
 			ancestors := strings.Split(path[len(dir)+1:], string(os.PathSeparator))
-			key := strings.Join(ancestors, "/")
+			key := strings.ToLower(strings.Join(ancestors, "/"))
 			filesMap[key] = api.File{
 				Name:        info.Name(),
 				Ancestors:   ancestors,


### PR DESCRIPTION
File systems may be case-insensitive but file path comparison was done using a map, which has case sensitive keys. This results in duplicate file entries as downloading disregards case sensitivity.
Fixed this by converting all keys to lower case.