### PR TITLE
fix: percent sign in filenames

### DIFF
--- a/internal/file/file.go
+++ b/internal/file/file.go
@@ -116,10 +116,14 @@ func CleanseFolderFileName(name string) string {
 	name = strings.Replace(name, "?", " ", -1)
 	name = strings.Replace(name, "*", " ", -1)
 
-	// We can ignore the error (if any) because it would just mean
-	// that the "%XX" that appears in the name is legit, and not
-	// because of URL encoding.
-	name, _ = url.QueryUnescape(name)
+	// If there is an error, it would just mean that the "%XX" that appears
+	// in the name is legit, and not because of URL encoding.
+	unescapedName, err := url.QueryUnescape(name)
+
+	// If there is an error, unescapedName will be an empty string
+	if err == nil {
+		name = unescapedName
+	}
 
 	// Removes leading and trailing spaces (32) and periods (46)
 	name = strings.TrimFunc(name, func(r rune) bool {


### PR DESCRIPTION
<!-- Please set your PR title following the [Conventional Commits guidelines](https://www.conventionalcommits.org/en/v1.0.0/#summary). -->

### 🖼️ Description
<!-- Explain the context behind this PR and what this PR seeks to accomplish. -->
<!-- Link to any existing issues/PRs this PR is related to. -->

Lominus application crashes when attempting to download a file that has a percent sign (`%`) in the filename that does not follow URL encoding (e.g., `Ethanol 95 %.pdf`)

### ✨ What's Changed?
<!-- Provide a detailed list of changes (point form) made in this PR. -->
- Check for any errors returned by the `url.QueryUnescape()` function during cleansing of filenames

### 🧪 How Has This Been Tested? <!-- (Remove section if not applicable) -->
<!-- Describe in detail how you tested your changes and how your PR can be tested. -->

With the new changes, the Lominus application successfully downloads the following files from a pharmaceutical science (PHS) module:
- `Ethanol 95 %.pdf`
- `Hydrochloric acid (37%).pdf`
- `Iron(III) chloride (solid 97%).pdf`

### 🏎️ Review checklist
<!-- Cross out the text using the markdown strikethrough syntax if not applicable. -->
<!-- For example: - [ ] ~~Not applicable item~~ -->
- [ ] Have you conducted thorough regression testing?
- [ ] Have you included comprehensive tests covering new features or changes?
